### PR TITLE
require json

### DIFF
--- a/capistrano-deployinfo.gemspec
+++ b/capistrano-deployinfo.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-deployinfo"
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ["Bob Breznak"]
   spec.email         = ["bob.breznak@gmail.com"]
   spec.description   = %q{Capistrano tasks that write information about deploy into a project for quick referenceCapistrano tasks that write information about deploy into a project for quick reference.}

--- a/lib/capistrano/tasks/deployinfo.rake
+++ b/lib/capistrano/tasks/deployinfo.rake
@@ -1,3 +1,5 @@
+require 'json'
+
 namespace :deploy do
   task :write_info do
     on roles(fetch(:deployinfo_roles)) do

--- a/lib/capistrano/tasks/deployinfo.rake
+++ b/lib/capistrano/tasks/deployinfo.rake
@@ -24,6 +24,7 @@ end
 
 namespace :load do
   task :defaults do
+    set :deployinfo_path, -> { release_path }
     set :deployinfo_roles, :all
     set :deployinfo_dir, 'public'
     set :deployinfo_filename, 'deploy.json'


### PR DESCRIPTION
(Backtrace restricted to imported tasks)
cap aborted!
NoMethodError: undefined method `to_json' for #Hash:0x007fc8735d0370
